### PR TITLE
Typo fixed in update_2.x.inc.php

### DIFF
--- a/install/updates/froxlor/update_2.x.inc.php
+++ b/install/updates/froxlor/update_2.x.inc.php
@@ -281,7 +281,7 @@ EOF;
 			file_put_contents($complete_filedir . '/froxlor_master_cronjob.php', $compCron);
 			Update::lastStepStatus(0);
 		} else {
-			$cron_run_cmd = 'chmod +x ' . FileDir::makeCorrectFile(Froxlor::getInstallDir() . '/bin/froxlor-cli') . PHO_EOL;
+			$cron_run_cmd = 'chmod +x ' . FileDir::makeCorrectFile(Froxlor::getInstallDir() . '/bin/froxlor-cli') . PHP_EOL;
 			$cron_run_cmd .= FileDir::makeCorrectFile(Froxlor::getInstallDir() . '/bin/froxlor-cli') . ' froxlor:cron -r 99';
 			Update::lastStepStatus(1, 'manual commands needed', 'Please run the following commands manually:<br><pre>' . $cron_run_cmd . '</pre>');
 		}


### PR DESCRIPTION
PHO_EOL => PHP_EOL

# Description

Typo fixed in the update lib. This will cause an error while updating froxlor from 0.10.x running on PHP 8.1.
![Screenshot_20230116_210413](https://user-images.githubusercontent.com/5796295/212758991-7d010466-7f79-415e-916d-c79cb85b308b.png)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Fixed locally and run the updater again

**Test Configuration**:

* Distribution: Debian 11
* Webserver: Apache2
* PHP: 8.1 FPM (sury)
* etc.etc.: DocRoot /var/www/froxlor

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
